### PR TITLE
Update setup.py

### DIFF
--- a/Extension/C/profile_py2/my_mod/setup.py
+++ b/Extension/C/profile_py2/my_mod/setup.py
@@ -1,6 +1,6 @@
 from distutils.core import setup, Extension
 
-my_module = Extension('my_module', sources=['my_module.c'])
+my_module = Extension('my_module', sources=['my_module.c'], extra_compile_args=["-std=c99"])
 
 setup(name='my_module',
       version='1.0',


### PR DESCRIPTION
fix error which happened in CentOS7 default environment:
```
error: 'for' loop initial declarations are only allowed in C99 mode
```