### PR TITLE
docs(gil): fix typo

### DIFF
--- a/Interpreter/gil/gil.md
+++ b/Interpreter/gil/gil.md
@@ -44,7 +44,7 @@ you can call `sys.setcheckinterval()` to set other **tick** count value instead 
 
 because the **tick** is not time-based, some thread might run far longer than other threads
 
-in multi-core machine, if two threads both running CPU-bound tasks, the os might schedule the two threads running on different cores, there might be a situation that one thread holding the **gil** executing it's task in it's **100 ticks cycle** in a core, while the thread in the other core wakes up preiodly try to acquire the **gil** but fail, spinning the CPU
+in multi-core machine, if two threads both running CPU-bound tasks, the os might schedule the two threads running on different cores, there might be a situation that one thread holding the **gil** executing it's task in it's **100 ticks cycle** in a core, while the thread in the other core wakes up periodically try to acquire the **gil** but fail, spinning the CPU
 
 the job(thread) schedule mechanism is fully controlled by the operating system, the thread handling IO-bound task have to wait for other thread to release the **gil**, and other thread might re-acquire the **gil** after it release the **gil**, which makes the current IO-bound task thread wait even longer (actually, the thread that cause os's context-switch by it self will have higher priority than those thread forced by os, programmer can utilize this feature by putting the IO-bound thread to sleep as soon as possible)
 


### PR DESCRIPTION
[English] Fixing a typo in ./Interpreter/gil/gil.md#thread-scheduling-before-python32.