### PR TITLE
docs(gil): fix typos, grammar, cap, and punct

### DIFF
--- a/Interpreter/gil/gil.md
+++ b/Interpreter/gil/gil.md
@@ -189,7 +189,7 @@ static void take_gil(PyThreadState *tstate)
 
 ## switch_cond and switch_mutex
 
-**switch_cond** is another condition variable, combined with **switch_mutex** can be used for making sure that the thread acquiring the **GIL** is not the thread releasing the **GIL**, avoiding a waste of the time slice.
+**switch_cond** is another condition variable, combined with **switch_mutex** can be used for making sure that the thread acquiring the **GIL** is not the thread that released the **GIL**, avoiding a waste of the time slice.
 
 It can be turned off without the definition of `FORCE_SWITCHING`.
 


### PR DESCRIPTION
This PR includes fixing:
- Typos
- Grammar
- Capitalization
- Punctuation

In Interpreter/gil/gil.md.